### PR TITLE
add nix support and newer servant version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,30 @@
+with import <nixpkgs> {};
+
+let
+  hpkgs = haskellPackages.override {
+    overrides = self: super: {
+    };
+  };
+  ghc = hpkgs.ghcWithPackages (p: with p; [
+    aeson
+    postgresql-simple
+    postgresql-simple-migration
+    containers
+    formatting
+    servant-server
+    servant-auth
+    servant-auth-server
+    servant-client
+    http-client
+    resource-pool
+  ]);
+in runCommand "servant-starter-app" { buildInputs = [ ghc hpkgs.ghcid ]; } ''
+  cp -vr ${./.} ./app
+  mkdir -pv $out/bin
+  chmod -R +w .
+  find ./
+  cd app/src
+  ghc ../app/Main.hs -o $out/bin/servant-starter-app
+  ${binutils-unwrapped}/bin/strip $out/bin/servant-starter-app
+  patchelf --shrink-rpath $out/bin/servant-starter-app
+''

--- a/src/App.hs
+++ b/src/App.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 module App
   ( startApp
   ) where
@@ -6,7 +7,7 @@ import Database (initializeDatabase)
 import Network.Wai.Handler.Warp (run)
 import Resource (API, proxy, routes)
 import Servant
-       (Application, Context((:.), EmptyContext), Server, enter,
+       (Application, Context((:.), EmptyContext), Server,
         serveWithContext)
 import Servant.Auth.Server
        (IsSecure(NotSecure), cookieIsSecure, def, defaultJWTSettings,
@@ -34,4 +35,4 @@ app appContext@AppContext {..} =
   in serveWithContext proxy context $ server appContext
 
 server :: AppContext -> Server API
-server context = enter (convert context) routes
+server context = (convert context) routes

--- a/src/Database/Users.hs
+++ b/src/Database/Users.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Database.Users
   ( getByEmail
   , get

--- a/src/Model/Credentials.hs
+++ b/src/Model/Credentials.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Model.Credentials
   ( Password(..)
   , Credentials(..)

--- a/src/Model/User.hs
+++ b/src/Model/User.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Model.User
   ( User(..)
   , HashedPassword(..)

--- a/src/Resource.hs
+++ b/src/Resource.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeOperators #-}
 module Resource
   ( API
   , proxy

--- a/src/Resource/Session.hs
+++ b/src/Resource/Session.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Resource.Session where
 
 import Control.Monad.Trans (liftIO)

--- a/src/Resource/User.hs
+++ b/src/Resource/User.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
 module Resource.User
   ( UserAPI
   , userAPI

--- a/src/Resource/Utils.hs
+++ b/src/Resource/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Resource.Utils
   ( orElseThrow
   ) where

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
 module Types
   ( App
   , AppContext(..)
@@ -9,7 +13,8 @@ import Control.Monad.Reader (ReaderT, asks, liftIO, runReaderT)
 import Control.Monad.Trans.Maybe (runMaybeT)
 import Data.Pool (Pool, withResource)
 import Database (Connection, Fetch)
-import Servant ((:~>), Handler, runReaderTNat)
+import Servant (Handler)
+import Servant.Server (hoistServer)
 import Servant.Auth.Server (CookieSettings, JWTSettings)
 
 data AppContext = AppContext
@@ -22,8 +27,9 @@ data AppContext = AppContext
 
 type App = ReaderT AppContext Handler
 
-convert :: AppContext -> (App :~> Handler)
-convert = runReaderTNat
+--convert :: AppContext -> (App :~> Handler)
+--convert = hoistServer
+convert = undefined
 
 runDB :: forall a. Fetch a -> App (Maybe a)
 runDB op = do

--- a/src/Types/Entity.hs
+++ b/src/Types/Entity.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Types.Entity
   ( Entity(..)
   , Id


### PR DESCRIPTION
This is a work in progress, but puts into each file the language pragmas needed and adds a default.nix for building. I'm working on getting it working with servant 0.14, but stuck on the `runReaderTNat`/`enter` -> `hoistServerWithContext` conversion. I put an undefined in to make sure everything else compiles for now.